### PR TITLE
Add Flavor Support

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -164,6 +164,11 @@ class DiscordHandler:
                         response += "\nEigenAdmin"
                     await message.channel.send(response)
 
+                elif command.lower() == "list_flavors":
+                    r = requests.get("https://www.eigentrust.net:31415/categories")
+                    categories = json.loads(r.text)
+                    await message.channel.send("Available Flavors:\n\n" + ("\n".join(categories)))
+
                 elif command.lower() == "add_trust_react":
                     if is_dm:
                         await message.channel.send("Error: You can only use this command in a server.")

--- a/bot/database_migration/update.py
+++ b/bot/database_migration/update.py
@@ -3,6 +3,7 @@ from database_migration.versions import (
     v0_2_1,
     v0_3_0,
     v0_4_0,
+    v0_4_1,
 )
 from typing import TYPE_CHECKING
 import warnings
@@ -16,6 +17,7 @@ main_database_versions = {
     "0.2.1": v0_2_1.update,
     "0.3.0": v0_3_0.update,
     "0.4.0": v0_4_0.update,
+    "0.4.1": v0_4_1.update,
 }
 
 

--- a/bot/database_migration/versions/v0_4_1.py
+++ b/bot/database_migration/versions/v0_4_1.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from database import DatabaseManager
+
+
+def update(database: "DatabaseManager") -> None:
+    with database as db:
+        db.execute("ALTER TABLE pending_votes ADD COLUMN flavor TEXT")
+        db.execute("UPDATE bot_settings SET value='0.4.1' WHERE setting='version'")

--- a/bot/reacts.py
+++ b/bot/reacts.py
@@ -1,6 +1,7 @@
 from database import DatabaseManager
 from helpers import create_temp_user, send_dm
 from typing import TYPE_CHECKING
+import urllib.parse
 import asyncio
 import discord
 import emojis
@@ -82,7 +83,7 @@ async def process_possible_trust_react(
                 "Due to your security settings, you'll need to enter your password to vote for "
                 + f"{message.author.name}#{message.author.discriminator}.  Please go to "
                 + f"http://discord.eigentrust.net/vote?voter={voter_id}&votee={votee_id}"
-                + f"&message={payload.message_id}&flavor={flavor} to vote.",
+                + f"&message={payload.message_id}&flavor={urllib.parse.quote(flavor)} to vote.",
             )
             return
         assert r.status_code == 200
@@ -129,6 +130,8 @@ async def process_magnifying_glass(
         if not row:
             print("Server is not connected?")
             return
+        reacts = json.loads(row["reactions"])
+        categories = list(reacts.values())
         result = db.execute("SELECT * FROM connections WHERE id=:id", {"id": voter_id})
         row = result.fetchone()
         if not row:
@@ -207,9 +210,37 @@ async def process_magnifying_glass(
         response = (
             f"You have voted for {message.author.name}#{message.author.discriminator} (ID "
             + f"{votee_id}) {vote_count} "
-            + ("times.\n\n" if vote_count != 1 else "time.\n\n")
-            + f"Their score within your trust network is {trust_score}."
+            + ("times" if vote_count != 1 else "time") + ".\n"
+            + f"Their general score within your trust network is {trust_score}."
         )
+        for flavor in categories:
+            if flavor == "general":
+                continue
+            data["flavor"] = flavor
+            r = requests.post(
+                "https://www.eigentrust.net:31415/get_vote_count", data=json.dumps(data), headers=headers
+            )
+            if r.status_code != 200:
+                await send_dm(
+                    payload.member, f"Error checking vote count: `{r.text}` Error Code: `{r.status_code}`."
+                )
+                return
+            vote_count = str(json.loads(r.text)["votes"])
+            r = requests.post(
+                "https://www.eigentrust.net:31415/get_score", data=json.dumps(data), headers=headers
+            )
+            if r.status_code != 200:
+                await send_dm(
+                    payload.member, f"Error getting trust score: `{r.text}` Error Code: `{r.status_code}`."
+                )
+                return
+            trust_score = str(json.loads(r.text)["score"])
+            response += (
+                f"\n\nYou have voted for {message.author.name}#{message.author.discriminator} (ID "
+                + f"{votee_id}) {vote_count} "
+                + ("times" if vote_count != 1 else "time") + f" in the {flavor} flavor.\n"
+                + f"Their {flavor} score within your trust network is {trust_score}."
+            )
         await send_dm(payload.member, response)
 
 
@@ -263,15 +294,15 @@ async def process_remove_reaction(
                 print(f"{r.status_code}: {r.text}")
                 r.raise_for_status()
             db.execute(
-                "INSERT INTO pending_votes (voter_id, message_id, channel_id, guild_id, votee_id) VALUES (?, ?, ?, ?, ?)",
-                (voter_id, payload.message_id, payload.channel_id, payload.guild_id, votee_id),
+                "INSERT INTO pending_votes (voter_id, message_id, channel_id, guild_id, votee_id, flavor) VALUES (?, ?, ?, ?, ?, ?)",
+                (voter_id, payload.message_id, payload.channel_id, payload.guild_id, votee_id, flavor),
             )
             await send_dm(
                 member,
                 "Due to your security settings, you'll need to enter your password to vote for "
                 + f"{message.author.name}#{message.author.discriminator}.  Please go to "
                 + f"http://discord.eigentrust.net/vote?voter={voter_id}&votee={votee_id}"
-                + f"&message={payload.message_id}&amount=-1&flavor={flavor} to vote.",
+                + f"&message={payload.message_id}&amount=-1&flavor={urllib.parse.quote(flavor)} to vote.",
             )
             return
         assert r.status_code == 200

--- a/flask/routes/api.py
+++ b/flask/routes/api.py
@@ -96,13 +96,13 @@ def connect() -> Response:
 
 
 def cast_vote() -> Response:
-    password, voter_id, votee_id, message_id, amount = get_params(
-        ["password", "voter_id", "votee_id", "message_id", "amount"]
+    password, voter_id, votee_id, message_id, flavor, amount = get_params(
+        ["password", "voter_id", "votee_id", "message_id", "flavor", "amount"]
     )
     with DatabaseManager() as db:
         result = db.execute(
-            "SELECT * FROM pending_votes WHERE voter_id=:voter_id AND votee_id=:votee_id AND message_id=:message_id",
-            {"voter_id": voter_id, "votee_id": votee_id, "message_id": message_id},
+            "SELECT * FROM pending_votes WHERE voter_id=:voter_id AND votee_id=:votee_id AND message_id=:message_id AND flavor=:flavor",
+            {"voter_id": voter_id, "votee_id": votee_id, "message_id": message_id, "flavor": flavor},
         )
         vote_row = result.fetchone()
         if not vote_row:
@@ -114,6 +114,7 @@ def cast_vote() -> Response:
         "from": voter_id,
         "password": password,
         "password_type": "raw_password",
+        "flavor": flavor,
         "amount": amount,
     }
     headers = {

--- a/flask/routes/api.py
+++ b/flask/routes/api.py
@@ -1,6 +1,7 @@
 from database import DatabaseManager
 from flask import redirect, request, Response
 from helpers import get_params
+import urllib.parse
 import dotenv
 import json
 import os
@@ -99,6 +100,8 @@ def cast_vote() -> Response:
     password, voter_id, votee_id, message_id, flavor, amount = get_params(
         ["password", "voter_id", "votee_id", "message_id", "flavor", "amount"]
     )
+    flavor = urllib.parse.unquote(flavor)
+    print(f"{flavor=}")
     with DatabaseManager() as db:
         result = db.execute(
             "SELECT * FROM pending_votes WHERE voter_id=:voter_id AND votee_id=:votee_id AND message_id=:message_id AND flavor=:flavor",
@@ -125,8 +128,8 @@ def cast_vote() -> Response:
         return Response(r.text, r.status_code)
     with DatabaseManager() as db:
         db.execute(
-            "DELETE FROM pending_votes WHERE voter_id=:voter_id AND votee_id=:votee_id AND message_id=:message_id",
-            {"voter_id": voter_id, "votee_id": votee_id, "message_id": message_id},
+            "DELETE FROM pending_votes WHERE voter_id=:voter_id AND votee_id=:votee_id AND message_id=:message_id AND flavor=:flavor",
+            {"voter_id": voter_id, "votee_id": votee_id, "message_id": message_id, "flavor": flavor},
         )
     return Response(r.text, r.status_code)
 

--- a/flask/templates/lookup.html
+++ b/flask/templates/lookup.html
@@ -23,7 +23,7 @@
                         var data = JSON.parse(this.responseText);
                         document.getElementById("output").innerHTML = "You have voted for this user ";
                         document.getElementById("output").innerHTML += data["votes"] + ((data["votes"] == 1) ? " time." : " times.");
-                        document.getElementById("output").innerHTML += "<br>Their score within your trust network is ";
+                        document.getElementById("output").innerHTML += "<br>Their general score within your trust network is ";
                         document.getElementById("output").innerHTML += data["score"] + ".";
                     }else if(this.readyState == 4 && this.status == 403){
                         document.getElementById("notice").innerHTML = this.responseText;

--- a/flask/templates/vote.html
+++ b/flask/templates/vote.html
@@ -16,11 +16,12 @@
                 var voter_id = getUrlParameters()["voter"];
                 var votee_id = getUrlParameters()["votee"];
                 var message = getUrlParameters()["message"];
+                var flavor = getUrlParameters()["flavor"];
                 var amount = getUrlParameters()["amount"];
                 if(!amount){
                     amount = 1
                 }
-                var data = {"password": password, "voter_id": voter_id, "votee_id": votee_id, "message_id": message, "amount": amount};
+                var data = {"password": password, "voter_id": voter_id, "votee_id": votee_id, "message_id": message, "flavor": flavor, "amount": amount};
 
                 var xhttp = new XMLHttpRequest();
                 xhttp.onreadystatechange = function(){


### PR DESCRIPTION
Created database version 0.4.1
    Added flavor column to pending votes.
Added flavor support in trust reacts and in voting routes.
Added list_flavors command to give all available flavors.
Fixed trust links when the flavor has a space in it.
Added support for multiple flavor lookups.
    When you do the :mag: react it will now lookup your trust for every flavor in the server.
Fixed remove trust link flavor support.
Fixed bug where all pending votes were deleted when one vote of the same flavor was authorized.
Changed lookup page to mimic the multiple flavor lookup verbiage.